### PR TITLE
Add genotype mapping source switch logic

### DIFF
--- a/back/api/genesys.js
+++ b/back/api/genesys.js
@@ -192,7 +192,7 @@ const transformInitialToFinal = (initialbody) => {
 };
 
 async function fetchAllAccessionNumbers(finalbody) {
-  const baseUrl = `${config.genesysServer}/api/v1/acn/query`;
+  const baseUrl = `${config.genesysServer}/api/v2/acn/query`;
   const limit = 10000;
   const allAccessionNumbers = [];
 
@@ -230,7 +230,7 @@ async function fetchAllAccessionNumbers(finalbody) {
 }
 
 router.get("/passportFilter/possibleValues", async (req, res) => {
-  const url = `${config.genesysServer}/api/v1/acn/filter`;
+  const url = `${config.genesysServer}/api/v2/acn/filter`;
 
   try {
     const result = await postToGenesysWithRetry(url, { _text: " " });
@@ -274,7 +274,7 @@ router.post("/accession/filters", async (req, res) => {
     f: req.query.f,
   });
 
-  const url = `${config.genesysServer}/api/v1/acn/filter${queryString}`;
+  const url = `${config.genesysServer}/api/v2/acn/filter${queryString}`;
 
   try {
     const response = await postToGenesysWithRetry(url, req.body);
@@ -386,7 +386,7 @@ router.post("/accession/query", async (req, res) => {
     }
 
     const queryString = queryParams.toString();
-    let url = `${config.genesysServer}/api/v1/acn/query`;
+    let url = `${config.genesysServer}/api/v2/acn/query`;
 
     if (queryString) {
       url += `?${queryString}`;
@@ -581,7 +581,7 @@ router.post("/wiews/filter", async (req, res) => {
 
 router.post("/wiews/decode", async (req, res) => {
   const body = req.body;
-  const url = `${config.genesysServer}/api/v1/vocabulary/wiews/decode`;
+  const url = `${config.genesysServer}/api/v2/vocabulary/wiews/decode`;
 
   try {
     const response = await postToGenesysWithRetry(url, body);
@@ -626,6 +626,75 @@ router.post("/subset/filter", async (req, res) => {
 
     res.status(error.response?.status || 500).send({
       message: "Genesys subset filter request failed",
+      error: getErrorDetails(error),
+    });
+  }
+});
+
+router.post("/genotype-ids", async (req, res) => {
+  try {
+    const { accessionNumbers } = req.body || {};
+
+    if (!Array.isArray(accessionNumbers) || accessionNumbers.length === 0) {
+      return res.status(400).send({
+        message: "Body must include a non-empty 'accessionNumbers' array.",
+      });
+    }
+
+    const cleanedAccessions = [
+      ...new Set(
+        accessionNumbers
+          .filter((item) => typeof item === "string")
+          .map((item) => item.trim())
+          .filter(Boolean),
+      ),
+    ];
+
+    if (cleanedAccessions.length === 0) {
+      return res.status(400).send({
+        message: "No valid accession numbers provided.",
+      });
+    }
+
+    const url = `${config.genesysServer}/api/v2/acn/genotype-ids?l=500`;
+
+    const response = await postToGenesysWithRetry(url, {
+      accessionNumbers: cleanedAccessions,
+    });
+
+    const content = Array.isArray(response.data?.content)
+      ? response.data.content
+      : [];
+
+    const Samples = content
+      .filter((item) => item?.acceNumb && item?.genotypeId)
+      .map((item) => ({
+        Accession: item.acceNumb,
+        Sample: item.genotypeId,
+        Status: "Completed",
+        doi: item.doi || item.accession?.doi || null,
+        serverUrl: item.serverUrl || null,
+        source: "genesys",
+      }));
+
+    return res.status(200).send({
+      Samples,
+      totalRequestedAccessions: cleanedAccessions.length,
+      totalMappedAccessions: new Set(Samples.map((item) => item.Accession))
+        .size,
+      source: "genesys",
+    });
+  } catch (error) {
+    logger.error(
+      `API Error in /genotype-ids: ${JSON.stringify(
+        getErrorDetails(error),
+        null,
+        2,
+      )}`,
+    );
+
+    return res.status(error.response?.status || 500).send({
+      message: "Genesys genotype IDs request failed",
       error: getErrorDetails(error),
     });
   }

--- a/back/api/gigwa.js
+++ b/back/api/gigwa.js
@@ -458,7 +458,6 @@ router.post("/searchSamplesInDatasets", async (req, res) => {
         step: "Map accessions to genotype IDs",
       });
     }
-    logger.info(JSON.stringify(samplesObj));
     const genotypeIds = samplesObj.Samples.map((obj) => obj.Sample).filter(
       Boolean,
     );

--- a/back/api/gigwa.js
+++ b/back/api/gigwa.js
@@ -3,6 +3,9 @@ const router = express.Router();
 const axios = require("axios");
 const logger = require("../middlewares/logger");
 const config = require("../config/appConfig");
+const {
+  getGenotypeMappingsByAccessions,
+} = require("../utils/genotypeMappingResolver");
 const rawBase = process.env.BASE_PATH || "";
 const BASE_PATH = rawBase.replace(/\/+$/, "");
 
@@ -438,33 +441,30 @@ router.post("/searchSamplesInDatasets", async (req, res) => {
     const token = getGigwaTokenFromBody(req.body);
 
     const samplesObj = await runApiStep(
-      "Map Genesys accessions to genotype IDs",
+      "Map accessions to genotype IDs",
       async () => {
-        const response = await axios.post(
-          `${config.genolinkServer}${BASE_PATH}/api/internalApi/mapAccessionToGenotypeId`,
-          {
-            Accessions: accessions,
-          },
-        );
-
-        return response.data;
+        return await getGenotypeMappingsByAccessions(accessions);
       },
     );
 
     if (!samplesObj?.Samples || !Array.isArray(samplesObj.Samples)) {
-      logger.error("Invalid response from mapAccessionToGenotypeId API", {
+      logger.error("Invalid response from genotype mapping resolver", {
         samplesObj,
       });
 
       return res.status(500).send({
         message:
-          "Invalid response from mapAccessionToGenotypeId API. Expected Samples array.",
-        step: "Map Genesys accessions to genotype IDs",
+          "Invalid response from genotype mapping resolver. Expected Samples array.",
+        step: "Map accessions to genotype IDs",
       });
     }
-
-    const genotypeIds = samplesObj.Samples.map((obj) => obj.Sample || []);
-    const Accessions = samplesObj.Samples.map((obj) => obj.Accession || []);
+    logger.info(JSON.stringify(samplesObj));
+    const genotypeIds = samplesObj.Samples.map((obj) => obj.Sample).filter(
+      Boolean,
+    );
+    const Accessions = samplesObj.Samples.map((obj) => obj.Accession).filter(
+      Boolean,
+    );
 
     const accessionByGenotypeId = new Map(
       samplesObj.Samples.map((item) => [item.Sample, item.Accession]),

--- a/back/config/appConfig.js
+++ b/back/config/appConfig.js
@@ -1,11 +1,33 @@
 require("dotenv").config();
 
+const allowedGenotypeMappingSources = [
+  "internal",
+  "genesys",
+  "hybrid_internal_first",
+  "hybrid_genesys_first",
+];
+
+const defaultGenotypeMappingSource = "hybrid_internal_first";
+
+const genotypeMappingSource =
+  process.env.GENOTYPE_MAPPING_SOURCE || defaultGenotypeMappingSource;
+
+if (!allowedGenotypeMappingSources.includes(genotypeMappingSource)) {
+  throw new Error(
+    `Invalid GENOTYPE_MAPPING_SOURCE "${genotypeMappingSource}". ` +
+      `Allowed values are: ${allowedGenotypeMappingSources.join(", ")}`,
+  );
+}
+
 module.exports = {
   gigwaServers: JSON.parse(process.env.GIGWA_SERVERS || "{}"),
   germinateServer: process.env.GERMINATE_SERVER,
   genolinkServer: process.env.GENOLINK_SERVER,
   genesysServer: process.env.GENESYS_SERVER,
   genolinkServerPort: process.env.GENOLINK_SERVER_PORT || 4000,
+
+  genotypeMappingSource,
+
   sampStatMapping: {
     100: "Wild",
     110: "Natural",

--- a/back/utils/genotypeMappingResolver.js
+++ b/back/utils/genotypeMappingResolver.js
@@ -1,0 +1,201 @@
+const axios = require("axios");
+
+const config = require("../config/appConfig");
+const logger = require("../middlewares/logger");
+
+const BASE_PATH = process.env.BASE_PATH || "";
+
+const normaliseAccessions = (accessions = []) => {
+  if (!Array.isArray(accessions)) {
+    return [];
+  }
+
+  return [
+    ...new Set(
+      accessions
+        .filter((item) => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  ];
+};
+
+const normaliseSamples = (samples = [], source = "unknown") => {
+  if (!Array.isArray(samples)) {
+    return [];
+  }
+
+  return samples
+    .filter((item) => item && typeof item === "object")
+    .map((item) => ({
+      Accession: item.Accession ?? item.accession ?? item.acceNumb ?? null,
+      Sample: item.Sample ?? item.sample ?? item.genotypeId ?? null,
+      Status: item.Status ?? item.status ?? "Completed",
+      doi: item.doi ?? null,
+      serverUrl: item.serverUrl ?? null,
+      source: item.source ?? source,
+    }))
+    .filter((item) => item.Accession && item.Sample);
+};
+
+const getInternalMappingsByAccessions = async (accessions) => {
+  const cleanedAccessions = normaliseAccessions(accessions);
+
+  if (cleanedAccessions.length === 0) {
+    return [];
+  }
+
+  try {
+    const response = await axios.post(
+      `${config.genolinkServer}${BASE_PATH}/api/internalApi/mapAccessionToGenotypeId`,
+      {
+        Accessions: cleanedAccessions,
+      },
+    );
+
+    return normaliseSamples(response.data?.Samples, "internal");
+  } catch (error) {
+    if (error.response?.status === 404) {
+      logger.info(
+        "No internal genotype mappings found for provided accessions.",
+      );
+      return [];
+    }
+
+    logger.error("Error fetching internal genotype mappings:", {
+      status: error.response?.status,
+      message: error.response?.data?.message || error.message,
+      url: error.config?.url,
+    });
+
+    throw error;
+  }
+};
+
+const getGenesysMappingsByAccessions = async (accessions) => {
+  const cleanedAccessions = normaliseAccessions(accessions);
+
+  if (cleanedAccessions.length === 0) {
+    return [];
+  }
+
+  const response = await axios.post(
+    `${config.genolinkServer}${BASE_PATH}/api/genesys/genotype-ids`,
+    {
+      accessionNumbers: cleanedAccessions,
+    },
+  );
+
+  return normaliseSamples(response.data?.Samples, "genesys");
+};
+
+const getMappedAccessionSet = (mappings = []) => {
+  return new Set(mappings.map((item) => item.Accession).filter(Boolean));
+};
+
+const getMissingAccessions = (requestedAccessions = [], mappings = []) => {
+  const mappedAccessions = getMappedAccessionSet(mappings);
+
+  return requestedAccessions.filter(
+    (accession) => !mappedAccessions.has(accession),
+  );
+};
+
+const mergePrimaryWithFallback = (primaryMappings = [], fallbackMappings = []) => {
+  const primaryMappedAccessions = getMappedAccessionSet(primaryMappings);
+
+  const fallbackOnlyMappings = fallbackMappings.filter(
+    (item) => !primaryMappedAccessions.has(item.Accession),
+  );
+
+  return [...primaryMappings, ...fallbackOnlyMappings];
+};
+
+const getHybridInternalFirstMappings = async (accessions) => {
+  const cleanedAccessions = normaliseAccessions(accessions);
+
+  const internalMappings = await getInternalMappingsByAccessions(
+    cleanedAccessions,
+  );
+
+  const missingAccessions = getMissingAccessions(
+    cleanedAccessions,
+    internalMappings,
+  );
+
+  if (missingAccessions.length === 0) {
+    return internalMappings;
+  }
+
+  const genesysMappings = await getGenesysMappingsByAccessions(
+    missingAccessions,
+  );
+
+  return mergePrimaryWithFallback(internalMappings, genesysMappings);
+};
+
+const getHybridGenesysFirstMappings = async (accessions) => {
+  const cleanedAccessions = normaliseAccessions(accessions);
+
+  const genesysMappings = await getGenesysMappingsByAccessions(
+    cleanedAccessions,
+  );
+
+  const missingAccessions = getMissingAccessions(
+    cleanedAccessions,
+    genesysMappings,
+  );
+
+  if (missingAccessions.length === 0) {
+    return genesysMappings;
+  }
+
+  const internalMappings = await getInternalMappingsByAccessions(
+    missingAccessions,
+  );
+
+  return mergePrimaryWithFallback(genesysMappings, internalMappings);
+};
+
+const getGenotypeMappingsByAccessions = async (
+  accessions,
+  mappingSource = config.genotypeMappingSource,
+) => {
+  const cleanedAccessions = normaliseAccessions(accessions);
+
+  if (cleanedAccessions.length === 0) {
+    return {
+      Samples: [],
+      totalRequestedAccessions: 0,
+      totalMappedAccessions: 0,
+      source: mappingSource,
+    };
+  }
+
+  let Samples;
+
+  if (mappingSource === "internal") {
+    Samples = await getInternalMappingsByAccessions(cleanedAccessions);
+  } else if (mappingSource === "genesys") {
+    Samples = await getGenesysMappingsByAccessions(cleanedAccessions);
+  } else if (mappingSource === "hybrid_internal_first") {
+    Samples = await getHybridInternalFirstMappings(cleanedAccessions);
+  } else if (mappingSource === "hybrid_genesys_first") {
+    Samples = await getHybridGenesysFirstMappings(cleanedAccessions);
+  } else {
+    throw new Error(`Unsupported genotype mapping source: ${mappingSource}`);
+  }
+
+  return {
+    Samples,
+    totalRequestedAccessions: cleanedAccessions.length,
+    totalMappedAccessions: getMappedAccessionSet(Samples).size,
+    source: mappingSource,
+  };
+};
+
+module.exports = {
+  getGenotypeMappingsByAccessions,
+  getInternalMappingsByAccessions,
+  getGenesysMappingsByAccessions,
+};

--- a/front/src/api/GenesysApi.js
+++ b/front/src/api/GenesysApi.js
@@ -1,5 +1,5 @@
 import BaseApi from "./BaseApi";
-import { genolinkServer } from "../config/apiConfig";
+import { genolinkServer, genotypeMappingSource } from "../config/apiConfig";
 import { BASE_PATH } from "../config/basePath";
 import { genolinkInternalApi } from "../pages/Home";
 import country2Region from "shared-data/Country2Region.json";
@@ -140,6 +140,41 @@ class GenesysApi extends BaseApi {
     return allSubsets;
   }
 
+  async genotypeInfo(accessionNumbers) {
+    if (!Array.isArray(accessionNumbers) || accessionNumbers.length === 0) {
+      return {
+        Samples: [],
+        totalRequestedAccessions: 0,
+        totalMappedAccessions: 0,
+        source: "genesys",
+      };
+    }
+
+    const cleanedAccessions = [
+      ...new Set(
+        accessionNumbers
+          .filter((item) => typeof item === "string")
+          .map((item) => item.trim())
+          .filter(Boolean),
+      ),
+    ];
+
+    if (cleanedAccessions.length === 0) {
+      return {
+        Samples: [],
+        totalRequestedAccessions: 0,
+        totalMappedAccessions: 0,
+        source: "genesys",
+      };
+    }
+
+    const endpoint = `${GENESYS_API_BASE}/genotype-ids`;
+
+    return await this.post(endpoint, {
+      accessionNumbers: cleanedAccessions,
+    });
+  }
+
   async fetchInitialFilterData(
     dispatch,
     userInput = " ",
@@ -278,6 +313,162 @@ class GenesysApi extends BaseApi {
     }
   }
 
+  normaliseAccessionNumber(accession) {
+    return String(accession || "")
+      .replace(/"/g, "")
+      .trim()
+      .toUpperCase();
+  }
+
+  addUniqueAccessions(targetMap, accessions = []) {
+    if (!Array.isArray(accessions)) {
+      return;
+    }
+
+    accessions.forEach((accession) => {
+      const cleaned = String(accession || "")
+        .replace(/"/g, "")
+        .trim();
+      const normalised = this.normaliseAccessionNumber(cleaned);
+
+      if (cleaned && normalised && !targetMap.has(normalised)) {
+        targetMap.set(normalised, cleaned);
+      }
+    });
+  }
+
+  getInternalGenotypedAccessionsForRequest(requestBody = {}) {
+    const internalGenotypedAccessions = Array.isArray(this.genotypedAccessions)
+      ? this.genotypedAccessions
+      : [];
+
+    const internalMap = new Map();
+    this.addUniqueAccessions(internalMap, internalGenotypedAccessions);
+
+    const requestedAccessions = Array.isArray(requestBody.accessionNumbers)
+      ? requestBody.accessionNumbers
+      : [];
+
+    if (requestedAccessions.length > 0) {
+      return requestedAccessions
+        .map((accession) =>
+          String(accession || "")
+            .replace(/"/g, "")
+            .trim(),
+        )
+        .filter((accession) =>
+          internalMap.has(this.normaliseAccessionNumber(accession)),
+        );
+    }
+
+    return Array.from(internalMap.values());
+  }
+
+  async fetchAllGenesysGenotypedAccessions(filterData = {}) {
+    const pageSize = 10000;
+    const select = "accessionNumber";
+
+    const requestBody = JSON.parse(JSON.stringify(filterData || {}));
+    requestBody.genotyped = true;
+
+    const firstEndpoint =
+      `${GENESYS_API_BASE}/accession/query` +
+      `?p=0&l=${pageSize}&select=${encodeURIComponent(select)}`;
+
+    const firstResponse = await this.post(firstEndpoint, requestBody);
+
+    const accessionMap = new Map();
+
+    this.addUniqueAccessions(
+      accessionMap,
+      (firstResponse.content || []).map((item) => item.accessionNumber),
+    );
+
+    const totalPages =
+      firstResponse.totalPages ||
+      Math.ceil((firstResponse.totalElements || 0) / pageSize) ||
+      1;
+
+    const filterCode = firstResponse.filterCode;
+
+    for (let page = 1; page < totalPages; page++) {
+      const endpoint = filterCode
+        ? `${GENESYS_API_BASE}/accession/query?f=${filterCode}&p=${page}&l=${pageSize}&select=${encodeURIComponent(select)}`
+        : `${GENESYS_API_BASE}/accession/query?p=${page}&l=${pageSize}&select=${encodeURIComponent(select)}`;
+
+      const response = await this.post(endpoint, filterCode ? {} : requestBody);
+
+      this.addUniqueAccessions(
+        accessionMap,
+        (response.content || []).map((item) => item.accessionNumber),
+      );
+    }
+
+    return Array.from(accessionMap.values());
+  }
+
+  async buildGenotypedRequestBody(filterData = {}) {
+    const requestBody = JSON.parse(JSON.stringify(filterData || {}));
+
+    const internalGenotypedAccessions =
+      this.getInternalGenotypedAccessionsForRequest(requestBody);
+
+    if (genotypeMappingSource === "internal") {
+      requestBody.accessionNumbers =
+        internalGenotypedAccessions.length > 0
+          ? internalGenotypedAccessions
+          : ["__INVALID__"];
+
+      delete requestBody.genotyped;
+
+      return requestBody;
+    }
+
+    if (genotypeMappingSource === "genesys") {
+      requestBody.genotyped = true;
+      delete requestBody.accessionNumbers;
+
+      return requestBody;
+    }
+
+    if (
+      genotypeMappingSource === "hybrid_internal_first" ||
+      genotypeMappingSource === "hybrid_genesys_first"
+    ) {
+      if (internalGenotypedAccessions.length === 0) {
+        requestBody.genotyped = true;
+        delete requestBody.accessionNumbers;
+
+        return requestBody;
+      }
+
+      const genesysGenotypedAccessions =
+        await this.fetchAllGenesysGenotypedAccessions(requestBody);
+
+      const mergedAccessionsMap = new Map();
+
+      this.addUniqueAccessions(
+        mergedAccessionsMap,
+        internalGenotypedAccessions,
+      );
+      this.addUniqueAccessions(mergedAccessionsMap, genesysGenotypedAccessions);
+
+      const mergedAccessions = Array.from(mergedAccessionsMap.values());
+
+      requestBody.accessionNumbers =
+        mergedAccessions.length > 0 ? mergedAccessions : ["__INVALID__"];
+
+      delete requestBody.genotyped;
+
+      return requestBody;
+    }
+
+    requestBody.genotyped = true;
+    delete requestBody.accessionNumbers;
+
+    return requestBody;
+  }
+
   async applyFilter(
     filterData,
     dispatch,
@@ -294,31 +485,7 @@ class GenesysApi extends BaseApi {
       const endpointOverview = `${GENESYS_API_BASE}/overview?l=${limit}`;
 
       if (hasGenotype) {
-        const requestBody = JSON.parse(JSON.stringify(filterData));
-
-        const genotypedAccessionSet = new Set(
-          this.genotypedAccessions.map((acc) =>
-            String(acc).replace(/"/g, "").trim().toUpperCase(),
-          ),
-        );
-
-        if (
-          Array.isArray(requestBody.accessionNumbers) &&
-          requestBody.accessionNumbers.length > 0
-        ) {
-          const existingAccessions = requestBody.accessionNumbers.map((acc) =>
-            String(acc).replace(/"/g, "").trim().toUpperCase(),
-          );
-
-          const matchedAccessions = existingAccessions.filter((acc) =>
-            genotypedAccessionSet.has(acc),
-          );
-
-          requestBody.accessionNumbers =
-            matchedAccessions.length > 0 ? matchedAccessions : ["__INVALID__"];
-        } else {
-          requestBody.accessionNumbers = Array.from(genotypedAccessionSet);
-        }
+        const requestBody = await this.buildGenotypedRequestBody(filterData);
 
         const [queryData, filterDataResponse] = await Promise.all([
           this.post(endpointQuery, requestBody),
@@ -501,7 +668,6 @@ class GenesysApi extends BaseApi {
     pageSize,
     dispatch,
     searchResults,
-    hasGenotype,
     selectedColumnIds = null,
   }) {
     try {
@@ -516,18 +682,51 @@ class GenesysApi extends BaseApi {
           }&l=${pageSize}&select=${encodeURIComponent(select)}`;
 
       const response = await this.post(endpoint, {});
-
-      if (hasGenotype) {
-        dispatch(setSearchResults([...searchResults, ...response.content]));
-      } else {
-        dispatch(setSearchResults([...searchResults, ...response.content]));
-      }
+      dispatch(setSearchResults([...searchResults, ...response.content]));
 
       dispatch(setPassportCurrentPage(passportCurrentPage + 1));
     } catch (error) {
       console.error("Error fetching more data:", error);
       throw error;
     }
+  }
+
+  async fetchGenesysGenotypeIdMapByAccessions(accessions = []) {
+    const accessionMap = new Map();
+    this.addUniqueAccessions(accessionMap, accessions);
+
+    const cleanedAccessions = Array.from(accessionMap.values());
+
+    if (cleanedAccessions.length === 0) {
+      return {};
+    }
+
+    const batchSize = 500;
+    const genotypeIdMap = {};
+
+    for (let i = 0; i < cleanedAccessions.length; i += batchSize) {
+      const chunk = cleanedAccessions.slice(i, i + batchSize);
+
+      try {
+        const response = await this.genotypeInfo(chunk);
+        const samples = Array.isArray(response?.Samples)
+          ? response.Samples
+          : [];
+
+        samples.forEach((sample) => {
+          if (sample.Accession && sample.Sample) {
+            genotypeIdMap[sample.Accession] = sample.Sample;
+          }
+        });
+      } catch (error) {
+        console.error(
+          "Failed to fetch Genesys genotype IDs for export:",
+          error,
+        );
+      }
+    }
+
+    return genotypeIdMap;
   }
 
   async downloadFilteredData(filterData, selectedMappings, hasGenotype) {
@@ -547,9 +746,13 @@ class GenesysApi extends BaseApi {
         `${GENESYS_API_BASE}/accession/query` +
         `?p=0&l=${pageSize}&select=${encodeURIComponent(select)}`;
 
+      const requestBody = hasGenotype
+        ? await this.buildGenotypedRequestBody(filterData)
+        : filterData;
+
       const firstGenesysResult = await this.post(
         firstGenesysEndpoint,
-        filterData,
+        requestBody,
       );
 
       let allResults = firstGenesysResult.content || [];
@@ -569,7 +772,10 @@ class GenesysApi extends BaseApi {
           `?f=${filterCode}&p=${genesysPage}&l=${pageSize}&select=${encodeURIComponent(select)}`;
 
         genesysRequests.push(async () => {
-          const response = await this.post(endpoint, {});
+          const response = await this.post(
+            endpoint,
+            filterCode ? {} : requestBody,
+          );
           return response;
         });
       }
@@ -586,19 +792,30 @@ class GenesysApi extends BaseApi {
       }
 
       if (allResults.length > 0) {
-        if (hasGenotype) {
-          allResults = allResults.filter((result) =>
-            this.genotypedAccessions.includes(result.accessionNumber),
-          );
-        }
-
         let figMapping = {};
+        let genesysGenotypeIdMap = {};
+
+        const accessionIds = allResults
+          .map((item) => item.accessionNumber)
+          .filter(Boolean);
+
+        const shouldExportGenotypeId = Object.values(selectedMappings).some(
+          (mapping) => mapping.apiParam === "GenotypeID",
+        );
 
         if (shouldDownloadFigsSet) {
-          const accessionIds = allResults.map((item) => item.accessionNumber);
-
           figMapping =
             await genolinkInternalApi.getFigsByAccessions(accessionIds);
+        }
+
+        if (
+          shouldExportGenotypeId &&
+          (genotypeMappingSource === "genesys" ||
+            genotypeMappingSource === "hybrid_internal_first" ||
+            genotypeMappingSource === "hybrid_genesys_first")
+        ) {
+          genesysGenotypeIdMap =
+            await this.fetchGenesysGenotypeIdMapByAccessions(accessionIds);
         }
 
         const selectedMappingsForTSV = { ...selectedMappings };
@@ -608,6 +825,7 @@ class GenesysApi extends BaseApi {
           allResults,
           selectedMappingsForTSV,
           figMapping,
+          genesysGenotypeIdMap,
         );
 
         this.downloadFile(
@@ -623,7 +841,7 @@ class GenesysApi extends BaseApi {
     }
   }
 
-  generateTSV(data, selectedMappings, figMapping) {
+  generateTSV(data, selectedMappings, figMapping, genesysGenotypeIdMap = {}) {
     const header = Object.keys(selectedMappings)
       .map((field) => selectedMappings[field].tsvHeader)
       .join("\t");
@@ -644,7 +862,21 @@ class GenesysApi extends BaseApi {
             const index = this.genotypedAccessions.indexOf(
               item.accessionNumber,
             );
-            return index !== -1 ? this.genotypedSamples[index] : "N/A";
+
+            const internalGenotypeId =
+              index !== -1 ? this.genotypedSamples[index] : null;
+
+            const genesysGenotypeId =
+              genesysGenotypeIdMap[item.accessionNumber] || null;
+
+            if (
+              genotypeMappingSource === "genesys" ||
+              genotypeMappingSource === "hybrid_genesys_first"
+            ) {
+              return genesysGenotypeId || internalGenotypeId || "N/A";
+            }
+
+            return internalGenotypeId || genesysGenotypeId || "N/A";
           }
 
           if (fieldPath === "figsSet") {

--- a/front/src/components/metadata/MetadataSearchResultTable.jsx
+++ b/front/src/components/metadata/MetadataSearchResultTable.jsx
@@ -17,6 +17,7 @@ import {
 } from "../../redux/passport/passportActions";
 import { genesysApi } from "../../pages/Home";
 import { genolinkInternalApi } from "../../pages/Home";
+import { genotypeMappingSource } from "../../config/apiConfig";
 import country2Region from "shared-data/Country2Region.json";
 
 import { batch } from "react-redux";
@@ -90,6 +91,9 @@ const MetadataSearchResultTable = ({ filterCode, hasGenotype, filterBody }) => {
     ),
   );
   const [figMapping, setFigMapping] = useState({});
+  const [genesysGenotypeByAccession, setGenesysGenotypeByAccession] = useState(
+    {},
+  );
   const [isPending, startTransition] = useTransition();
   const [columnWidths, setColumnWidths] = useState({});
   const resizeStateRef = useRef(null);
@@ -137,6 +141,14 @@ const MetadataSearchResultTable = ({ filterCode, hasGenotype, filterBody }) => {
 
   const genotypedSamples = genesysApi.genotypedSamples || [];
 
+  const shouldFetchGenesysGenotypeIds = useMemo(() => {
+    return (
+      genotypeMappingSource === "genesys" ||
+      genotypeMappingSource === "hybrid_internal_first" ||
+      genotypeMappingSource === "hybrid_genesys_first"
+    );
+  }, []);
+
   useEffect(() => {
     if (!searchResults || searchResults.length === 0) {
       setSelectAll(false);
@@ -164,6 +176,60 @@ const MetadataSearchResultTable = ({ filterCode, hasGenotype, filterBody }) => {
 
     fetchFigs();
   }, [searchResults]);
+
+  useEffect(() => {
+    if (!shouldFetchGenesysGenotypeIds) return;
+    if (!searchResults || searchResults.length === 0) return;
+
+    let cancelled = false;
+
+    const fetchGenesysGenotypeIdsForVisibleRows = async () => {
+      try {
+        const accessionsToCheck = searchResults
+          .map((item) => item.accessionNumber)
+          .filter(Boolean)
+          .filter((acc) => !genotypedIndexByAcc.has(acc))
+          .filter((acc) => !genesysGenotypeByAccession[acc]);
+
+        const uniqueAccessionsToCheck = [...new Set(accessionsToCheck)];
+
+        if (uniqueAccessionsToCheck.length === 0) return;
+
+        const response = await genesysApi.genotypeInfo(uniqueAccessionsToCheck);
+
+        const samples = Array.isArray(response?.Samples)
+          ? response.Samples
+          : [];
+
+        if (cancelled || samples.length === 0) return;
+
+        setGenesysGenotypeByAccession((prev) => {
+          const next = { ...prev };
+
+          samples.forEach((sample) => {
+            if (sample.Accession && sample.Sample) {
+              next[sample.Accession] = sample.Sample;
+            }
+          });
+
+          return next;
+        });
+      } catch (error) {
+        console.error("Failed to fetch Genesys genotype IDs:", error);
+      }
+    };
+
+    fetchGenesysGenotypeIdsForVisibleRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    searchResults,
+    shouldFetchGenesysGenotypeIds,
+    genotypedIndexByAcc,
+    genesysGenotypeByAccession,
+  ]);
 
   const getColumnWidth = useCallback(
     (id) => {
@@ -398,14 +464,28 @@ const MetadataSearchResultTable = ({ filterCode, hasGenotype, filterBody }) => {
           <tbody>
             {searchResults?.map((item, index) => {
               const acc = item.accessionNumber;
-              const status =
-                statusByAcc.get(acc) ??
-                (acc?.startsWith("AGG") ? "TBC" : "N/A");
               const gIdx = genotypedIndexByAcc.get(acc) ?? -1;
-              const genotypeID =
+
+              const internalGenotypeID =
                 gIdx !== -1 && Array.isArray(genotypedSamples)
                   ? genotypedSamples[gIdx]
-                  : "N/A";
+                  : null;
+
+              const genesysGenotypeID = genesysGenotypeByAccession[acc] || null;
+
+              const genotypeID =
+                genotypeMappingSource === "genesys" ||
+                genotypeMappingSource === "hybrid_genesys_first"
+                  ? genesysGenotypeID || internalGenotypeID || "N/A"
+                  : internalGenotypeID || genesysGenotypeID || "N/A";
+
+              const status =
+                statusByAcc.get(acc) ??
+                (genesysGenotypeID
+                  ? "Completed"
+                  : acc?.startsWith("AGG")
+                    ? "TBC"
+                    : "N/A");
               const isExpanded = expandedRow === index;
 
               return (

--- a/front/src/components/metadata/filters/SearchFilters.jsx
+++ b/front/src/components/metadata/filters/SearchFilters.jsx
@@ -46,6 +46,7 @@ import MetadataSearchResultTable from "../MetadataSearchResultTable";
 import DateRangeFilter from "./DateRangeFilter";
 import GenotypeExplorer from "../../genotype/GenotypeExplorer";
 import { genesysApi, genolinkInternalApi } from "../../../pages/Home";
+import { genotypeMappingSource } from "../../../config/apiConfig";
 import { Autocomplete, TextField, Chip, Box } from "@mui/material";
 
 const SearchFilters = ({ initialDataReady }) => {
@@ -126,6 +127,59 @@ const SearchFilters = ({ initialDataReady }) => {
   const wheatImage = "Wheat.PNG";
   const selectedUUIDs = selectedSubsets.map((item) => item.uuid);
 
+  const cleanGenotypeIds = (ids = []) => {
+    if (!Array.isArray(ids)) {
+      return [];
+    }
+
+    return [
+      ...new Set(
+        ids
+          .filter((id) => typeof id === "string")
+          .map((id) => id.replace(/"/g, "").trim())
+          .filter(Boolean),
+      ),
+    ];
+  };
+
+  const mapGenotypeIdsUsingInternalDb = async (ids = []) => {
+    const cleanedIds = cleanGenotypeIds(ids);
+
+    if (cleanedIds.length === 0) {
+      return [];
+    }
+
+    try {
+      const mappedAccessions =
+        await genolinkInternalApi.genotypeIdMapping(cleanedIds);
+
+      return Array.isArray(mappedAccessions)
+        ? mappedAccessions.map((acc) =>
+            acc.replace(/"/g, "").trim().toUpperCase(),
+          )
+        : [];
+    } catch (error) {
+      console.warn("Internal genotypeId mapping failed:", error);
+      return [];
+    }
+  };
+
+  const shouldUseInternalGenotypeIdMapping = () => {
+    return (
+      genotypeMappingSource === "internal" ||
+      genotypeMappingSource === "hybrid_internal_first" ||
+      genotypeMappingSource === "hybrid_genesys_first"
+    );
+  };
+
+  const shouldPassGenotypeIdsToGenesys = () => {
+    return (
+      genotypeMappingSource === "genesys" ||
+      genotypeMappingSource === "hybrid_internal_first" ||
+      genotypeMappingSource === "hybrid_genesys_first"
+    );
+  };
+
   useEffect(() => {
     const fetchFigs = async () => {
       try {
@@ -178,17 +232,21 @@ const SearchFilters = ({ initialDataReady }) => {
         let accessionNums = [];
 
         if (filterMode === "GenotypeId Filter" && genotypeIdsParam) {
-          const genotypeIdList = genotypeIdsParam
-            .split(",")
-            .map((id) => id.trim());
+          const genotypeIdList = cleanGenotypeIds(genotypeIdsParam.split(","));
+
           setFilterMode(filterMode);
-          try {
-            accessionNums =
-              await genolinkInternalApi.genotypeIdMapping(genotypeIdList);
-            setMappingFailed(accessionNums.length === 0);
-          } catch (e) {
-            console.warn("Genotype mapping failed, possibly 404:", e);
+
+          if (shouldUseInternalGenotypeIdMapping()) {
+            accessionNums = await mapGenotypeIdsUsingInternalDb(genotypeIdList);
+          }
+
+          if (
+            genotypeMappingSource === "internal" &&
+            (!accessionNums || accessionNums.length === 0)
+          ) {
             setMappingFailed(true);
+          } else {
+            setMappingFailed(false);
           }
         }
 
@@ -395,11 +453,10 @@ const SearchFilters = ({ initialDataReady }) => {
     let accessionNums1;
     let accessionNums2;
 
-    if (genotypeIds && genotypeIds.length > 0) {
-      accessionNums1 = await genolinkInternalApi.genotypeIdMapping(genotypeIds);
-      accessionNums1 = accessionNums1.map((acc) =>
-        acc.replace(/"/g, "").trim().toUpperCase(),
-      );
+    const cleanedGenotypeIds = cleanGenotypeIds(genotypeIds);
+
+    if (cleanedGenotypeIds.length > 0 && shouldUseInternalGenotypeIdMapping()) {
+      accessionNums1 = await mapGenotypeIdsUsingInternalDb(cleanedGenotypeIds);
     }
 
     if (selectedFig) {

--- a/front/src/config/apiConfig.js
+++ b/front/src/config/apiConfig.js
@@ -3,3 +3,18 @@ export const genesysServer = import.meta.env.VITE_GENESYS_SERVER;
 export const platforms = import.meta.env.VITE_PLATFORM?.split(",") || ["Gigwa"];
 export const REQUIRE_GIGWA_CREDENTIALS =
   import.meta.env.VITE_REQUIRE_GIGWA_CREDENTIALS === "true";
+
+const allowedGenotypeMappingSources = [
+  "internal",
+  "genesys",
+  "hybrid_internal_first",
+  "hybrid_genesys_first",
+];
+
+const defaultGenotypeMappingSource = "hybrid_internal_first";
+
+export const genotypeMappingSource = allowedGenotypeMappingSources.includes(
+  import.meta.env.VITE_GENOTYPE_MAPPING_SOURCE,
+)
+  ? import.meta.env.VITE_GENOTYPE_MAPPING_SOURCE
+  : defaultGenotypeMappingSource;

--- a/front/src/pages/Home.jsx
+++ b/front/src/pages/Home.jsx
@@ -9,6 +9,28 @@ import { loadSelectedColumnsFromStorage } from "../components/metadata/MetadataC
 export const genesysApi = new GenesysApi();
 export const genolinkInternalApi = new GenolinkInternalApi();
 
+const normaliseGenotypeStatusRows = (rows = []) => {
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+
+  return rows
+    .filter((row) => row && typeof row === "object")
+    .map((row) => ({
+      Accession: row.Accession ?? row.accession ?? row.acceNumb ?? null,
+      Sample: row.Sample ?? row.sample ?? row.genotypeId ?? null,
+      Status: row.Status ?? row.status ?? null,
+      doi: row.doi ?? null,
+      serverUrl: row.serverUrl ?? null,
+      source: row.source ?? "internal",
+    }))
+    .filter((row) => row.Accession);
+};
+
+const isCompletedGenotypeRow = (row) => {
+  return row.Status === "Completed" && row.Sample;
+};
+
 const Home = () => {
   const [initialDataReady, setInitialDataReady] = useState(false);
   const dispatch = useDispatch();
@@ -22,17 +44,25 @@ const Home = () => {
 
         if (cancelled) return;
 
-        const completedRows = rows.filter((r) => r.Status === "Completed");
+        const normalisedRows = normaliseGenotypeStatusRows(rows);
+        const completedRows = normalisedRows.filter(isCompletedGenotypeRow);
 
-        genesysApi.setGenotypeStatus(rows);
+        genesysApi.setGenotypeStatus(normalisedRows);
         genesysApi.setGenotypedAccessions(
-          completedRows.map((r) => r.Accession),
+          completedRows.map((row) => row.Accession),
         );
-        genesysApi.setGenotypedSamples(completedRows.map((r) => r.Sample));
+        genesysApi.setGenotypedSamples(completedRows.map((row) => row.Sample));
 
         setInitialDataReady(true);
       } catch (e) {
         console.error("Init error:", e);
+
+        if (!cancelled) {
+          genesysApi.setGenotypeStatus([]);
+          genesysApi.setGenotypedAccessions([]);
+          genesysApi.setGenotypedSamples([]);
+          setInitialDataReady(true);
+        }
       }
     };
 


### PR DESCRIPTION
This PR adds configurable genotype mapping source logic for internal, Genesys, and hybrid modes.

Main changes:
- Adds genotype mapping source configuration with hybrid_internal_first as the default.
- Adds Genesys genotype ID lookup support.
- Updates Gigwa genotype mapping flow to use the selected source.
- Updates frontend genotype filtering, table display, and export behaviour to support Genesys genotype IDs.
- Removes unnecessary debug logging.