### PR TITLE
Fix inconsistent accession count for multiple genotype IDs

### DIFF
--- a/back/api/gigwa.js
+++ b/back/api/gigwa.js
@@ -705,8 +705,13 @@ router.post("/searchSamplesInDatasets", async (req, res) => {
       ),
     ];
 
-    const numberOfPresentAccessions = uniqueGermplasmPresence.length;
+    const presentAccessions = [
+      ...new Set(
+        combinedResult.map((item) => item.accessionNumber).filter(Boolean),
+      ),
+    ];
 
+    const numberOfPresentAccessions = presentAccessions.length;
     return res.send({
       combinedResult,
       uniqueGermplasmPresence,


### PR DESCRIPTION
- This fixes the accession count when one accession is mapped to multiple genotype IDs.
- Previously, the endpoint counted unique genotype IDs as accessions, which could produce results such as "2 of 1 accessions".
- The endpoint now counts unique accession numbers while retaining all genotype IDs in the response.