### PR TITLE
Use backend mapped sample status values

### DIFF
--- a/front/src/api/GenesysApi.js
+++ b/front/src/api/GenesysApi.js
@@ -103,36 +103,6 @@ class GenesysApi extends BaseApi {
     return this.genotypedSamples;
   }
 
-  getSampleStatus(number) {
-    const sampStatMapping = {
-      100: "Wild",
-      110: "Natural",
-      120: "Semi-natural/wild",
-      130: "Semi-natural/sown",
-      200: "Weedy",
-      300: "Traditional cultivar/Landrace",
-      400: "Breeding/Research Material",
-      410: "Breeders Line",
-      411: "Synthetic population",
-      412: "Hybrid",
-      413: "Founder stock/base population",
-      414: "Inbred line",
-      415: "Segregating population",
-      416: "Clonal selection",
-      420: "Genetic stock",
-      421: "Mutant",
-      422: "Cytogenetic stocks",
-      423: "Other genetic stocks",
-      500: "Advanced/improved cultivar",
-      600: "GMO",
-      999: "Other",
-    };
-
-    const key = String(number);
-
-    return sampStatMapping[key] || "Unknown status";
-  }
-
   async getDonorInstituteFullName(donorList) {
     if (!donorList || donorList.length === 0) {
       return;
@@ -1086,7 +1056,7 @@ class GenesysApi extends BaseApi {
             return item["taxonomy.taxonName"] || "";
           }
           if (fieldPath === "sampStat") {
-            return this.getSampleStatus(item["sampStat"]) || "";
+            return item["sampStat"] || "";
           }
           if (fieldPath === "aliases") {
             return item.aliases && item.aliases.length > 0

--- a/front/src/components/metadata/MetadataColumns.jsx
+++ b/front/src/components/metadata/MetadataColumns.jsx
@@ -203,7 +203,7 @@ export function renderMetadataCell(colId, item, ctx) {
     }
 
     case "sampStat":
-      return ctx.getSampleStatus(item.sampStat) || "N/A";
+      return item.sampStat || "N/A";
 
     case "donorInstitute": {
       const name = item.donorName || "";

--- a/front/src/components/metadata/MetadataSearchResultTable.jsx
+++ b/front/src/components/metadata/MetadataSearchResultTable.jsx
@@ -25,35 +25,6 @@ import ExportFieldsModal from "./ExportFieldsModal";
 import { METADATA_COLUMNS, sanitizeSelectedColumns } from "./MetadataColumns";
 import styles from "./MetadataSearchResultTable.module.css";
 
-const sampStatMapping = {
-  100: "Wild",
-  110: "Natural",
-  120: "Semi-natural/wild",
-  130: "Semi-natural/sown",
-  200: "Weedy",
-  300: "Traditional cultivar/Landrace",
-  400: "Breeding/Research Material",
-  410: "Breeders Line",
-  411: "Synthetic population",
-  412: "Hybrid",
-  413: "Founder stock/base population",
-  414: "Inbred line",
-  415: "Segregating population",
-  416: "Clonal selection",
-  420: "Genetic stock",
-  421: "Mutant",
-  422: "Cytogenetic stocks",
-  423: "Other genetic stocks",
-  500: "Advanced/improved cultivar",
-  600: "GMO",
-  999: "Other",
-};
-
-function getSampleStatus(number) {
-  const key = String(number);
-  return sampStatMapping[key] || "Unknown status";
-}
-
 function formatDate(dateStr) {
   if (dateStr && dateStr.length === 8) {
     const year = dateStr.substring(0, 4);
@@ -573,7 +544,6 @@ const MetadataSearchResultTable = ({ filterCode, hasGenotype, filterBody }) => {
                   figsForAcc={figMapping[acc]}
                   visibleColumnIds={visibleColumnIds}
                   formatDate={formatDate}
-                  getSampleStatus={getSampleStatus}
                   countryByCode={countryByCode}
                 />
               );

--- a/front/src/components/metadata/ResultRow.jsx
+++ b/front/src/components/metadata/ResultRow.jsx
@@ -13,7 +13,6 @@ const ResultRow = React.memo(function ResultRow({
   genotypeID,
   figsForAcc,
   formatDate,
-  getSampleStatus,
   countryByCode,
 }) {
   const checked = useSelector(
@@ -32,7 +31,6 @@ const ResultRow = React.memo(function ResultRow({
     genotypeID,
     figsForAcc,
     formatDate,
-    getSampleStatus,
     countryByCode,
   };
 


### PR DESCRIPTION
## Summary
Removes frontend sample status mapping for accession query results because the backend now returns `sampStat` already mapped to its display value.

## Changes
- Removed the local `sampStat` mapping from metadata result rendering.
- Updated the Biological Status column to display `item.sampStat` directly.
- Removed unused `getSampleStatus` plumbing from `MetadataSearchResultTable` and `ResultRow`.
- Updated export formatting to use the backend-provided `sampStat` value directly.
- Kept filter/suggestion mapping unchanged because Genesys filters still require numeric `sampStat` codes.
