### PR TITLE
Add optional dataset DOI metadata

### DIFF
--- a/back/api/internalApi.js
+++ b/back/api/internalApi.js
@@ -11,6 +11,7 @@ const mapAccessionToGenotypeIdHandler = require("../utils/mapAccessionToGenotype
 const mapGenotypeIdToAccessionHandler = require("../utils/mapGenotypeIdToAccessionHandler");
 // const figMappingHandler = require("../utils/figMappingHandler");
 const mapFigToAccessionHandler = require("../utils/mapFigToAccessionHandler");
+const datasetDoiHandler = require("../utils/datasetDoiHandler");
 
 // router.post("/accessionMapping", accessionMappingHandler);
 router.post("/mapAccessionToGenotypeId", mapAccessionToGenotypeIdHandler);
@@ -20,6 +21,8 @@ router.post("/mapGenotypIdToAccession", mapGenotypeIdToAccessionHandler);
 
 // router.post("/figMapping", figMappingHandler);
 router.post("/mapFigToAccession", mapFigToAccessionHandler);
+
+router.post("/accession-dataset-info", datasetDoiHandler);
 
 // router.get("/getAllAccessionsCsv", async (req, res) => {
 //   try {

--- a/back/config/datasetDoiMappings.js
+++ b/back/config/datasetDoiMappings.js
@@ -1,0 +1,76 @@
+const DATASET_DOI_MAPPINGS = [
+  {
+    crop: "barley",
+    cropCode: "BARL",
+    datasetInfo: [
+      {
+        doi: "10.7910/DVN/H6SNVM",
+        url: "https://doi.org/10.7910/DVN/H6SNVM",
+      },
+      {
+        doi: "10.7910/DVN/LXU0WD",
+        url: "https://doi.org/10.7910/DVN/LXU0WD",
+      },
+    ],
+  },
+  {
+    crop: "wheat",
+    cropCode: "WHEA",
+    datasetInfo: [
+      {
+        doi: "10.7910/DVN/CRSI0B",
+        url: "https://doi.org/10.7910/DVN/CRSI0B",
+      },
+      {
+        doi: "10.7910/DVN/MOBTA8",
+        url: "https://doi.org/10.7910/DVN/MOBTA8",
+      },
+    ],
+  },
+  {
+    crop: "chickpea",
+    cropCode: "CHIC",
+    datasetInfo: [
+      {
+        doi: "10.7910/DVN/SQFKJW",
+        url: "https://doi.org/10.7910/DVN/SQFKJW",
+      },
+      {
+        doi: "10.7910/DVN/ECQ4NC",
+        url: "https://doi.org/10.7910/DVN/ECQ4NC",
+      },
+    ],
+  },
+  {
+    crop: "lentil",
+    cropCode: "LENS",
+    datasetInfo: [
+      {
+        doi: "10.7910/DVN/T0TDAS",
+        url: "https://doi.org/10.7910/DVN/T0TDAS",
+      },
+    ],
+  },
+  {
+    crop: "pea",
+    cropCode: "PEAS",
+    datasetInfo: [
+      {
+        doi: "10.7910/DVN/A6WGYS",
+        url: "https://doi.org/10.7910/DVN/A6WGYS",
+      },
+    ],
+  },
+  {
+    crop: "lupin",
+    cropCode: "LUPN",
+    datasetInfo: [
+      {
+        doi: "10.7910/DVN/FVTFIL",
+        url: "https://doi.org/10.7910/DVN/FVTFIL",
+      },
+    ],
+  },
+];
+
+module.exports = DATASET_DOI_MAPPINGS;

--- a/back/config/datasetDoiMappings.js
+++ b/back/config/datasetDoiMappings.js
@@ -4,10 +4,6 @@ const DATASET_DOI_MAPPINGS = [
     cropCode: "BARL",
     datasetInfo: [
       {
-        doi: "10.7910/DVN/H6SNVM",
-        url: "https://doi.org/10.7910/DVN/H6SNVM",
-      },
-      {
         doi: "10.7910/DVN/LXU0WD",
         url: "https://doi.org/10.7910/DVN/LXU0WD",
       },
@@ -18,10 +14,6 @@ const DATASET_DOI_MAPPINGS = [
     cropCode: "WHEA",
     datasetInfo: [
       {
-        doi: "10.7910/DVN/CRSI0B",
-        url: "https://doi.org/10.7910/DVN/CRSI0B",
-      },
-      {
         doi: "10.7910/DVN/MOBTA8",
         url: "https://doi.org/10.7910/DVN/MOBTA8",
       },
@@ -31,10 +23,6 @@ const DATASET_DOI_MAPPINGS = [
     crop: "chickpea",
     cropCode: "CHIC",
     datasetInfo: [
-      {
-        doi: "10.7910/DVN/SQFKJW",
-        url: "https://doi.org/10.7910/DVN/SQFKJW",
-      },
       {
         doi: "10.7910/DVN/ECQ4NC",
         url: "https://doi.org/10.7910/DVN/ECQ4NC",

--- a/back/utils/datasetDoiHandler.js
+++ b/back/utils/datasetDoiHandler.js
@@ -1,0 +1,37 @@
+const logger = require("../middlewares/logger");
+const {
+  resolveDatasetInfoForAccessions,
+} = require("./datasetDoiResolver");
+
+async function datasetDoiHandler(req, res) {
+  try {
+    const { accessions } = req.body ?? {};
+
+    if (!Array.isArray(accessions)) {
+      return res.status(400).json({
+        message: "Body must include an 'accessions' array.",
+      });
+    }
+
+    const cleaned = [
+      ...new Set(
+        accessions
+          .filter((accession) => typeof accession === "string")
+          .map((accession) => accession.trim())
+          .filter(Boolean),
+      ),
+    ];
+
+    const datasetInfoByAccession = resolveDatasetInfoForAccessions(cleaned);
+
+    res.status(200).json(datasetInfoByAccession);
+    logger.info(
+      `Resolved dataset DOI metadata for ${cleaned.length} accessions.`,
+    );
+  } catch (error) {
+    logger.error("Error resolving dataset DOI metadata:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+}
+
+module.exports = datasetDoiHandler;

--- a/back/utils/datasetDoiResolver.js
+++ b/back/utils/datasetDoiResolver.js
@@ -1,0 +1,51 @@
+const DATASET_DOI_MAPPINGS = require("../config/datasetDoiMappings");
+
+function accessionTokens(accession) {
+  return String(accession)
+    .toUpperCase()
+    .split(/[^A-Z0-9]+/)
+    .filter(Boolean);
+}
+
+function resolveDatasetInfoForAccession(accession) {
+  const tokenSet = new Set(accessionTokens(accession));
+  const mapping = DATASET_DOI_MAPPINGS.find((entry) =>
+    tokenSet.has(String(entry.cropCode).toUpperCase()),
+  );
+
+  if (!mapping || !Array.isArray(mapping.datasetInfo)) {
+    return null;
+  }
+
+  return mapping.datasetInfo.map((item) => ({ ...item }));
+}
+
+function resolveDatasetInfoForAccessions(accessions) {
+  if (!Array.isArray(accessions)) {
+    return {};
+  }
+
+  const result = {};
+  const seen = new Set();
+
+  accessions.forEach((accession) => {
+    if (typeof accession !== "string") {
+      return;
+    }
+
+    const cleaned = accession.trim();
+    if (!cleaned || seen.has(cleaned)) {
+      return;
+    }
+
+    seen.add(cleaned);
+    result[cleaned] = resolveDatasetInfoForAccession(cleaned);
+  });
+
+  return result;
+}
+
+module.exports = {
+  DATASET_DOI_MAPPINGS,
+  resolveDatasetInfoForAccessions,
+};

--- a/front/src/api/GenesysApi.js
+++ b/front/src/api/GenesysApi.js
@@ -818,9 +818,13 @@ class GenesysApi extends BaseApi {
 
       const batchSize = 50;
       const shouldDownloadFigsSet = Boolean(selectedMappings["FIGs Set"]);
+      const shouldDownloadDatasetDoi = Boolean(
+        selectedMappings["Dataset DOI"],
+      );
 
       const genesysSelectedMappings = { ...selectedMappings };
       delete genesysSelectedMappings["FIGs Set"];
+      delete genesysSelectedMappings["Dataset DOI"];
       const select = Object.keys(genesysSelectedMappings)
         .map((field) => genesysSelectedMappings[field].apiParam)
         .join(",");
@@ -876,6 +880,7 @@ class GenesysApi extends BaseApi {
 
       if (allResults.length > 0) {
         let figMapping = {};
+        let datasetInfoMapping = {};
         let genesysGenotypeIdMap = {};
 
         const accessionIds = allResults
@@ -889,6 +894,13 @@ class GenesysApi extends BaseApi {
         if (shouldDownloadFigsSet) {
           figMapping =
             await genolinkInternalApi.getFigsByAccessions(accessionIds);
+        }
+
+        if (shouldDownloadDatasetDoi) {
+          datasetInfoMapping =
+            await genolinkInternalApi.fetchDatasetInfoForAccessions(
+              accessionIds,
+            );
         }
 
         if (
@@ -909,6 +921,7 @@ class GenesysApi extends BaseApi {
           selectedMappingsForTSV,
           figMapping,
           genesysGenotypeIdMap,
+          datasetInfoMapping,
         );
 
         this.downloadFile(
@@ -924,7 +937,13 @@ class GenesysApi extends BaseApi {
     }
   }
 
-  generateTSV(data, selectedMappings, figMapping, genesysGenotypeIdMap = {}) {
+  generateTSV(
+    data,
+    selectedMappings,
+    figMapping,
+    genesysGenotypeIdMap = {},
+    datasetInfoMapping = {},
+  ) {
     const header = Object.keys(selectedMappings)
       .map((field) => selectedMappings[field].tsvHeader)
       .join("\t");
@@ -1005,6 +1024,21 @@ class GenesysApi extends BaseApi {
             return figMapping[item.accessionNumber]
               ? figMapping[item.accessionNumber].join(", ")
               : "";
+          }
+
+          if (fieldPath === "datasetDoi") {
+            const datasetInfo = datasetInfoMapping[item.accessionNumber];
+
+            if (!Array.isArray(datasetInfo) || datasetInfo.length === 0) {
+              return "N/A";
+            }
+
+            return (
+              datasetInfo
+                .map((entry) => entry?.doi || entry?.url)
+                .filter(Boolean)
+                .join(", ") || "N/A"
+            );
           }
 
           if (fieldPath === "institute.fullName") {

--- a/front/src/api/GenolinkInternalApi.js
+++ b/front/src/api/GenolinkInternalApi.js
@@ -112,6 +112,43 @@ class GenolinkInternalApi extends BaseApi {
       throw error;
     }
   }
+
+  async fetchDatasetInfoForAccessions(accessions) {
+    try {
+      const cleanedAccessions = [
+        ...new Set(
+          (Array.isArray(accessions) ? accessions : [])
+            .filter((accession) => typeof accession === "string")
+            .map((accession) => accession.trim())
+            .filter(Boolean),
+        ),
+      ];
+
+      if (cleanedAccessions.length === 0) {
+        return {};
+      }
+
+      const batchSize = 5000;
+      const datasetInfoMapping = {};
+
+      for (let i = 0; i < cleanedAccessions.length; i += batchSize) {
+        const chunk = cleanedAccessions.slice(i, i + batchSize);
+        const response = await this.post(
+          `${BASE_PATH}/api/internalApi/accession-dataset-info`,
+          {
+            accessions: chunk,
+          },
+        );
+
+        Object.assign(datasetInfoMapping, response);
+      }
+
+      return datasetInfoMapping;
+    } catch (error) {
+      console.error("Error fetching dataset DOI metadata:", error);
+      return {};
+    }
+  }
 }
 
 export default GenolinkInternalApi;

--- a/front/src/components/metadata/ExportFieldsModal.jsx
+++ b/front/src/components/metadata/ExportFieldsModal.jsx
@@ -45,6 +45,7 @@ const fieldsMapping = {
     tsvHeader: "Acquisition Date",
   },
   DOI: { apiParam: "doi", tsvHeader: "DOI" },
+  "Dataset DOI": { apiParam: "datasetDoi", tsvHeader: "Dataset DOI" },
   "Last Updated": { apiParam: "lastModifiedDate", tsvHeader: "Last Updated" },
   "Genotype Status": { apiParam: "status", tsvHeader: "Genotype Status" },
   GenotypeID: { apiParam: "GenotypeID", tsvHeader: "GenotypeID" },

--- a/front/src/components/metadata/MetadataColumns.jsx
+++ b/front/src/components/metadata/MetadataColumns.jsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import { genesysServer } from "../../config/apiConfig";
 import { germplasmStorageMapping } from "./filters/MultiSelectFilter";
 
@@ -67,6 +68,7 @@ export const METADATA_COLUMNS = [
     apiParams: ["acquisitionDate"],
   },
   { id: "doi", label: "DOI", apiParams: ["doi"] },
+  { id: "datasetDoi", label: "Dataset DOI", apiParams: [] },
   {
     id: "available",
     label: "Available for Distribution",
@@ -153,6 +155,7 @@ export function renderMetadataCell(colId, item, ctx) {
     case "accessionNumber":
       return (
         <a
+          className="metadata-table-link"
           href={`${genesysBaseUrl.origin}/a/${item.uuid}`}
           target="_blank"
           rel="noopener noreferrer"
@@ -234,6 +237,32 @@ export function renderMetadataCell(colId, item, ctx) {
 
     case "doi":
       return item.doi || "N/A";
+
+    case "datasetDoi": {
+      const datasetInfo = ctx.datasetInfoForAcc;
+      if (!Array.isArray(datasetInfo) || datasetInfo.length === 0) {
+        return "N/A";
+      }
+
+      return (
+        <span>
+          {datasetInfo.map((entry, index) => (
+            <Fragment key={`${entry.doi || entry.url}-${index}`}>
+              {index > 0 ? ", " : null}
+              <a
+                className="metadata-table-link"
+                href={entry.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(event) => event.stopPropagation()}
+              >
+                {entry.doi || entry.url}
+              </a>
+            </Fragment>
+          ))}
+        </span>
+      );
+    }
 
     case "available":
       return item.available === true

--- a/front/src/components/metadata/MetadataSearchResultTable.jsx
+++ b/front/src/components/metadata/MetadataSearchResultTable.jsx
@@ -89,6 +89,7 @@ const MetadataSearchResultTable = ({ filterCode, hasGenotype, filterBody }) => {
     ),
   );
   const [figMapping, setFigMapping] = useState({});
+  const [datasetInfoByAccession, setDatasetInfoByAccession] = useState({});
   const [genesysGenotypeIdsByAccession, setGenesysGenotypeIdsByAccession] =
     useState({});
 
@@ -166,6 +167,42 @@ const MetadataSearchResultTable = ({ filterCode, hasGenotype, filterBody }) => {
     );
   }, []);
 
+  const visibleCompletedAccessions = useMemo(() => {
+    if (!visibleColumnIds.includes("datasetDoi")) {
+      return [];
+    }
+
+    const accessions = (searchResults || [])
+      .filter((item) => {
+        const acc = item.accessionNumber;
+        const internalGenotypeIds = internalGenotypeIdsByAcc.get(acc) || [];
+        const genesysGenotypeIds = genesysGenotypeIdsByAccession[acc] || [];
+        const combinedGenotypeIds = combineGenotypeIds(
+          internalGenotypeIds,
+          genesysGenotypeIds,
+        );
+        const status =
+          statusByAcc.get(acc) ??
+          (genesysGenotypeIds.length > 0
+            ? "Completed"
+            : acc?.startsWith("AGG")
+              ? "TBC"
+              : "N/A");
+
+        return status === "Completed" || combinedGenotypeIds.length > 0;
+      })
+      .map((item) => item.accessionNumber)
+      .filter(Boolean);
+
+    return [...new Set(accessions)];
+  }, [
+    searchResults,
+    visibleColumnIds,
+    internalGenotypeIdsByAcc,
+    genesysGenotypeIdsByAccession,
+    statusByAcc,
+  ]);
+
   useEffect(() => {
     if (!searchResults || searchResults.length === 0) {
       setSelectAll(false);
@@ -193,6 +230,32 @@ const MetadataSearchResultTable = ({ filterCode, hasGenotype, filterBody }) => {
 
     fetchFigs();
   }, [searchResults]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchDatasetInfoForVisibleRows = async () => {
+      if (visibleCompletedAccessions.length === 0) {
+        setDatasetInfoByAccession({});
+        return;
+      }
+
+      const mapping =
+        await genolinkInternalApi.fetchDatasetInfoForAccessions(
+          visibleCompletedAccessions,
+        );
+
+      if (!cancelled) {
+        setDatasetInfoByAccession(mapping);
+      }
+    };
+
+    fetchDatasetInfoForVisibleRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [visibleCompletedAccessions]);
 
   useEffect(() => {
     if (!shouldFetchGenesysGenotypeIds) return;
@@ -542,6 +605,7 @@ const MetadataSearchResultTable = ({ filterCode, hasGenotype, filterBody }) => {
                   status={status}
                   genotypeID={genotypeID}
                   figsForAcc={figMapping[acc]}
+                  datasetInfoForAcc={datasetInfoByAccession[acc]}
                   visibleColumnIds={visibleColumnIds}
                   formatDate={formatDate}
                   countryByCode={countryByCode}

--- a/front/src/components/metadata/ResultRow.jsx
+++ b/front/src/components/metadata/ResultRow.jsx
@@ -12,6 +12,7 @@ const ResultRow = React.memo(function ResultRow({
   status,
   genotypeID,
   figsForAcc,
+  datasetInfoForAcc,
   formatDate,
   countryByCode,
 }) {
@@ -30,6 +31,7 @@ const ResultRow = React.memo(function ResultRow({
     status,
     genotypeID,
     figsForAcc,
+    datasetInfoForAcc,
     formatDate,
     countryByCode,
   };

--- a/front/src/tableStyles.css
+++ b/front/src/tableStyles.css
@@ -12,3 +12,20 @@
   text-overflow: ellipsis;
   max-width: 150px;
 }
+
+.metadata-table-link {
+  color: #005ea8;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: rgba(0, 94, 168, 0.45);
+  text-underline-offset: 2px;
+  transition:
+    color 0.15s ease,
+    text-decoration-color 0.15s ease;
+}
+
+.metadata-table-link:hover,
+.metadata-table-link:focus-visible {
+  color: #b42318;
+  text-decoration-color: currentColor;
+}


### PR DESCRIPTION
## Summary

Adds optional Dataset DOI metadata support without adding any new database fields or migrations.

## Changes

- Added backend Dataset DOI mapping config and resolver.
- Added `POST /api/internalApi/accession-dataset-info`.
- Resolves Dataset DOI metadata from accession crop-code tokens such as `WHEA`, `BARL`, `LENS`, `CHIC`, `PEAS`, and `LUPN`.
- Returns DOI arrays for mapped accessions and `null` for unmapped accessions.
- Added `Dataset DOI` column to the passport metadata table.
- Fetches Dataset DOI metadata only for currently viewed completed/genotyped accessions.
- Uses a deduplicated batched request instead of one request per accession.
- Displays Dataset DOI values as clickable links, with `N/A` when unavailable.
- Added `Dataset DOI` to the Export All Passport Data field options.
- Includes selected Dataset DOI values in the exported TSV.
- Added shared hover/focus styling for accession and Dataset DOI links in the metadata table.