### PR TITLE
fix: include studyDbId in Gigwa sample search results

### DIFF
--- a/back/api/gigwa.js
+++ b/back/api/gigwa.js
@@ -663,6 +663,7 @@ router.post("/searchSamplesInDatasets", async (req, res) => {
         germplasmDbId,
         accessionNumber,
         doi,
+        studyDbId,
         studyName:
           studyDbId != null
             ? (studyNamesByStudyDbId.get(studyDbId) ?? null)
@@ -988,7 +989,7 @@ router.post("/exportData", async (req, res) => {
     const body = {
       variantSetId,
       searchMode: 3,
-      getGT: true,
+      getGT: false,
       referenceName: linkagegroups || "",
       selectedVariantTypes: "",
       alleleCount: "",


### PR DESCRIPTION
# Summary

Fixes VCF exports using the wrong Gigwa variant set.

# Root Cause

The `/searchSamplesInDatasets` endpoint calculated `studyDbId` but did not include it in its response. As a result, `/exportData` could fall back to the hard-coded `AGG_BARLEY§1` variant set instead of using the selected dataset.

# Changes

- Added `studyDbId` to `/searchSamplesInDatasets` results.
- Ensured `/exportData` receives the correct variant-set identifier.
- Set `getGT` to `false` to match Gigwa’s export request.
