### PR TITLE
Reset filters when switching filter modes

### DIFF
--- a/front/src/components/metadata/filters/SearchFilters.jsx
+++ b/front/src/components/metadata/filters/SearchFilters.jsx
@@ -701,25 +701,37 @@ const SearchFilters = ({ initialDataReady }) => {
     convertDonorCodes();
   }, [donorCodeList]);
 
-  const handleResetFilter = async () => {
+  const resetFilters = async () => {
     setIsResetLoading(true);
 
     try {
       const filterCode = await genesysApi.resetFilter(dispatch);
       setFilterCode(filterCode);
-      setIsResetLoading(false);
       dispatch(setActiveFilters([]));
       dispatch(setResetTrigger(true));
       dispatch(setWildSearchValue(""));
+      setHasGenotype(false);
       if (instituteCheckedBoxesRef.current.length > 0)
         instituteCheckedBoxesRef.current = [];
       if (cropCheckedBoxesRef.current.length > 0)
         cropCheckedBoxesRef.current = [];
       setSubsetsTick((t) => t + 1);
     } catch (error) {
-      setIsResetLoading(false);
       console.error("Error handling reset filter:", error);
+    } finally {
+      setIsResetLoading(false);
     }
+  };
+
+  const handleResetFilter = () => resetFilters();
+
+  const handleFilterModeChange = (event) => {
+    const nextFilterMode = event.target.value;
+
+    if (nextFilterMode === filterMode) return;
+
+    setFilterMode(nextFilterMode);
+    resetFilters();
   };
 
   return (
@@ -787,7 +799,13 @@ const SearchFilters = ({ initialDataReady }) => {
           <TabPanel>
             <div className={styles.passportContentRow}>
               <div className={styles.genesysFilterContainer}>
-                <div className={styles.stickyTitles}>
+                {isResetLoading ? (
+                  <div className={styles.filterPanelLoading}>
+                    <LoadingComponent />
+                  </div>
+                ) : (
+                  <>
+                    <div className={styles.stickyTitles}>
                   <h4>Filters</h4>
                   {initialRequestSent &&
                     (!isLoading ? (
@@ -812,18 +830,20 @@ const SearchFilters = ({ initialDataReady }) => {
                       Reset Filter
                     </button>
                   </div>
-                </div>
-                <div className={styles.filterModeContainer}>
-                  <h5>Filter Mode:</h5>
-                  <select
-                    value={filterMode}
-                    onChange={(e) => setFilterMode(e.target.value)}
-                    className={styles.filterModeSelect}
-                  >
-                    <option value="Passport Filter">Passport Filter</option>
-                    <option value="Accession Filter">Accession Filter</option>
-                    <option value="GenotypeId Filter">GenotypeId Filter</option>
-                  </select>
+                  <div className={styles.filterModeContainer}>
+                    <h5>Filter Mode:</h5>
+                    <select
+                      value={filterMode}
+                      onChange={handleFilterModeChange}
+                      className={styles.filterModeSelect}
+                    >
+                      <option value="Passport Filter">Passport Filter</option>
+                      <option value="Accession Filter">Accession Filter</option>
+                      <option value="GenotypeId Filter">
+                        GenotypeId Filter
+                      </option>
+                    </select>
+                  </div>
                 </div>
                 <div>
                   <h5
@@ -1266,24 +1286,28 @@ const SearchFilters = ({ initialDataReady }) => {
                     </div>
                   </>
                 )}
-                <div>
-                  <label
-                    style={{
-                      fontWeight: 500,
-                      color: wildSearchValue ? "#888" : "inherit",
-                      cursor: wildSearchValue ? "not-allowed" : "pointer",
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={hasGenotype}
-                      onChange={handleChange}
-                      className={styles.mR8}
-                      disabled={wildSearchValue}
-                    />
-                    Check for genotype
-                  </label>
-                </div>
+                    {filterMode === "Passport Filter" && (
+                      <div>
+                        <label
+                          style={{
+                            fontWeight: 500,
+                            color: wildSearchValue ? "#888" : "inherit",
+                            cursor: wildSearchValue ? "not-allowed" : "pointer",
+                          }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={hasGenotype}
+                            onChange={handleChange}
+                            className={styles.mR8}
+                            disabled={wildSearchValue}
+                          />
+                          Check for genotype
+                        </label>
+                      </div>
+                    )}
+                  </>
+                )}
               </div>
               <div
                 className={styles.genesysResultContainer}

--- a/front/src/components/metadata/filters/SearchFilters.module.css
+++ b/front/src/components/metadata/filters/SearchFilters.module.css
@@ -149,6 +149,12 @@
   overflow-x: hidden;
 }
 
+.filterPanelLoading {
+  display: flex;
+  justify-content: center;
+  padding-top: 48px;
+}
+
 .fileInput {
   width: 210px;
   margin-left: 5px;
@@ -165,16 +171,27 @@
   top: 0;
   z-index: 10;
   background-color: #eff2f3;
+  margin-right: -10px;
+  padding-right: 10px;
+  padding-bottom: 12px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid #c8ced1;
+  box-shadow: 0 3px 4px rgba(0, 0, 0, 0.08);
 }
 
 .filterModeSelect {
-  margin-left: 15px;
   width: 180px;
 }
 
 .filterModeContainer {
   display: flex;
-  margin: 20px 0 40px 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.filterModeContainer h5 {
+  margin: 0;
 }
 
 .activeFiltersList {


### PR DESCRIPTION
## Summary

This PR improves filter-mode switching and the usability of the Genolink filter panel.

## Changes

- Automatically reset all Genesys filters when switching between:
  - Passport Filter
  - Accession Filter
  - Genotype ID Filter
- Reuse the existing Reset Filter logic instead of duplicating API and state updates.
- Call `GenesysApi.resetFilter` when the filter mode changes.
- Clear active filters, wild search, checkbox selections, accession numbers, genotype IDs, and other Redux-backed filter values.
- Restore the complete Genesys accession results after changing modes.
- Clear the “Check for genotype” selection during resets.
- Display “Check for genotype” only in Passport Filter mode.
- Show a loading state in both the results table and left filter panel while a reset request is running.
- Ensure loading state is cleared after both successful and failed requests.
- Keep Filter Mode, Apply Filter, and Reset Filter accessible in a sticky panel header.
- Improve sticky-header spacing, separation, and right-edge coverage.

## User impact

Users no longer carry hidden filters between filter modes. This prevents unexpectedly restricted results caused by the filters’ AND behavior.

The filter panel is also unavailable while Genesys reset data is loading, preventing new filters from being applied against an incomplete reset state.