### PR TITLE
add pedigree field to view and export

### DIFF
--- a/back/api/genesys.js
+++ b/back/api/genesys.js
@@ -424,6 +424,7 @@ router.post("/accession/query", async (req, res) => {
           "doi",
           "institute.id",
           "accessionName",
+          "ancest",
           "institute.owner.name",
           "genus",
           "taxonomy.grinTaxonomySpecies.speciesName",

--- a/front/src/components/metadata/ExportFieldsModal.jsx
+++ b/front/src/components/metadata/ExportFieldsModal.jsx
@@ -11,6 +11,7 @@ const fieldsMapping = {
     tsvHeader: "Holding Institute",
   },
   "Accession Name": { apiParam: "accessionName", tsvHeader: "Accession Name" },
+  Pedigree: { apiParam: "ancest", tsvHeader: "Pedigree" },
   Aliases: { apiParam: "aliases", tsvHeader: "Aliases" },
   Remarks: { apiParam: "remarks.remark", tsvHeader: "Remarks" },
   Taxonomy: { apiParam: "taxonomy.taxonName", tsvHeader: "Taxonomy" },

--- a/front/src/components/metadata/MetadataColumns.jsx
+++ b/front/src/components/metadata/MetadataColumns.jsx
@@ -34,6 +34,7 @@ export const METADATA_COLUMNS = [
     label: "Accession Name",
     apiParams: ["accessionName"],
   },
+  { id: "pedigree", label: "Pedigree", apiParams: ["ancest"] },
   { id: "aliases", label: "Aliases", apiParams: ["aliases"] },
   { id: "remarks", label: "Remarks", apiParams: ["remarks.remark"] },
   { id: "taxonomy", label: "Taxonomy", apiParams: ["taxonomy.taxonName"] },
@@ -170,6 +171,9 @@ export function renderMetadataCell(colId, item, ctx) {
 
     case "accessionName":
       return item.accessionName || "N/A";
+
+    case "pedigree":
+      return item.ancest || "N/A";
 
     case "aliases":
       return item.aliases && item.aliases.length > 1


### PR DESCRIPTION
# Summary

This PR adds pedigree information from Genesys to the Genolink passport data workflow.

# Changes

* Added the Genesys **ancest** field to the backend accession query select fields
* Added a user-facing **Pedigree** column to the passport metadata table
* Added **Pedigree** to the available column options in the **View** modal
* Allows users to show or hide the **Pedigree** column
* Added **Pedigree** to the **Export All Passport Data** field options
* Exports the Genesys **ancest** value under the **Pedigree** TSV header

# Passport Table Behaviour

* Pedigree information is retrieved from the Genesys **ancest** field
* The value is displayed to users under the **Pedigree** column
* Users can control whether the column is displayed through the **View** modal
* Existing passport table behaviour remains unchanged when the column is not selected

# Passport Export Behaviour

* **Pedigree** is available as a selectable field in **Export All Passport Data**
* When selected, the Genesys **ancest** value is included in the TSV export
* The exported column uses the user-friendly **Pedigree** header instead of the Genesys field name