### PR TITLE
add MLS status to passport view and export

### DIFF
--- a/back/api/genesys.js
+++ b/back/api/genesys.js
@@ -425,6 +425,7 @@ router.post("/accession/query", async (req, res) => {
           "institute.id",
           "accessionName",
           "ancest",
+          "mlsStatus",
           "institute.owner.name",
           "genus",
           "taxonomy.grinTaxonomySpecies.speciesName",

--- a/front/src/components/metadata/ExportFieldsModal.jsx
+++ b/front/src/components/metadata/ExportFieldsModal.jsx
@@ -12,6 +12,7 @@ const fieldsMapping = {
   },
   "Accession Name": { apiParam: "accessionName", tsvHeader: "Accession Name" },
   Pedigree: { apiParam: "ancest", tsvHeader: "Pedigree" },
+  "MLS Status": { apiParam: "mlsStatus", tsvHeader: "MLS Status" },
   Aliases: { apiParam: "aliases", tsvHeader: "Aliases" },
   Remarks: { apiParam: "remarks.remark", tsvHeader: "Remarks" },
   Taxonomy: { apiParam: "taxonomy.taxonName", tsvHeader: "Taxonomy" },

--- a/front/src/components/metadata/MetadataColumns.jsx
+++ b/front/src/components/metadata/MetadataColumns.jsx
@@ -3,7 +3,6 @@ import { genesysServer } from "../../config/apiConfig";
 import { germplasmStorageMapping } from "./filters/MultiSelectFilter";
 
 const genesysBaseUrl = new URL(genesysServer);
-genesysBaseUrl.hostname = genesysBaseUrl.hostname.replace(/^api\./, "www.");
 
 export const METADATA_FIELDS_STORAGE_KEY =
   "genolink.metadata.selectedFields.v1";
@@ -35,6 +34,7 @@ export const METADATA_COLUMNS = [
     apiParams: ["accessionName"],
   },
   { id: "pedigree", label: "Pedigree", apiParams: ["ancest"] },
+  { id: "mlsStatus", label: "MLS Status", apiParams: ["mlsStatus"] },
   { id: "aliases", label: "Aliases", apiParams: ["aliases"] },
   { id: "remarks", label: "Remarks", apiParams: ["remarks.remark"] },
   { id: "taxonomy", label: "Taxonomy", apiParams: ["taxonomy.taxonName"] },
@@ -174,6 +174,13 @@ export function renderMetadataCell(colId, item, ctx) {
 
     case "pedigree":
       return item.ancest || "N/A";
+
+    case "mlsStatus":
+      return item.mlsStatus === true
+        ? "True"
+        : item.mlsStatus === false
+          ? "False"
+          : "N/A";
 
     case "aliases":
       return item.aliases && item.aliases.length > 1


### PR DESCRIPTION
# Summary

This PR adds MLS status to Genolink passport data.

# Changes

* Added **mlsStatus** to the default Genesys accession query
* Added an **MLS Status** column to the passport results table
* Displays MLS status as **True**, **False**, or **N/A**
* Added **MLS Status** to the available passport export fields
* Updated accession links to use the Genesys website URL configured in the environment variables